### PR TITLE
Add default admin user

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -95,3 +95,20 @@ def reset_password(user_id: int, new_password: str):
         session.add(user)
         session.commit()
         return user
+
+
+def ensure_default_admin():
+    """Create the initial admin account if it doesn't exist."""
+    with get_session() as session:
+        exists = session.exec(select(User).where(User.username == "Admin")).first()
+        if not exists:
+            admin = User(
+                username="Admin",
+                hashed_password=get_password_hash("88888888"),
+                role="admin",
+            )
+            session.add(admin)
+            session.commit()
+            session.refresh(admin)
+            return admin
+    return None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,6 +36,9 @@ with get_session() as session:
                 session.add(word)
             session.commit()
 
+    # ensure default admin account exists
+    crud.ensure_default_admin()
+
 @app.post("/auth/register", response_model=Token)
 def register(user: UserCreate):
     u = crud.create_user(user.username, user.password)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -46,3 +46,14 @@ def test_stats_overview():
     assert r_stats.status_code == 200
     data = r_stats.json()
     assert {"reviewed", "due", "next_due"} <= data.keys()
+
+
+def test_default_admin_login():
+    r = client.post("/auth/login", data={"username": "Admin", "password": "88888888"})
+    assert r.status_code == 200
+    token = r.json()["access_token"]
+    assert token
+    headers = auth_header(token)
+    r_admin = client.get("/admin/users", headers=headers)
+    assert r_admin.status_code == 200
+    assert any(u["username"] == "Admin" for u in r_admin.json())


### PR DESCRIPTION
## Summary
- ensure a default admin account is created automatically
- test login with default admin credentials

## Testing
- `PYTHONPATH=`pwd` pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fc6c9280c832f84813620e20996cd