### PR TITLE
Add httpx and python-multipart to requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,5 @@ sqlmodel
 passlib[bcrypt]
 pytest
 python-jose[cryptography]
+httpx<0.27
+python-multipart


### PR DESCRIPTION
## Summary
- update backend requirements with httpx<0.27 and python-multipart
- verify dependencies install

## Testing
- `pip install -r backend/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_684fef2c6b80832fb2e12962632e183b