### PR TITLE
Read SECRET_KEY from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Word Cards
+
+This project contains a small FastAPI backend and tests for a vocabulary learning app.
+
+## Configuration
+
+- `SECRET_KEY` – signing key used for JWT tokens. If the environment variable is unset the application defaults to `"secret"`. Override it in production for better security.

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,8 +1,13 @@
 from passlib.context import CryptContext
 from jose import jwt
 from datetime import datetime, timedelta
+import os
 
-SECRET_KEY = "secret"
+# SECRET_KEY can be configured via environment variable.  It controls the
+# signing key for JWT tokens.  If not set, a default value of "secret" is used
+# which is sufficient for tests and local usage but should be overridden in
+# production.
+SECRET_KEY = os.getenv("SECRET_KEY", "secret")
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 120
 


### PR DESCRIPTION
## Summary
- allow overriding `SECRET_KEY` via environment variable
- document the setting in code comments and README

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q httpx python-multipart`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fef401a90832fa8b8b1214bf0ad0d