### PR TITLE
Fix token expiration timezone handling

### DIFF
--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,6 +1,6 @@
 from passlib.context import CryptContext
 from jose import jwt
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 SECRET_KEY = "secret"
 ALGORITHM = "HS256"
@@ -16,7 +16,7 @@ def verify_password(password: str, hashed: str) -> bool:
 
 def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
     to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    expire = datetime.now(UTC) + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
     to_encode.update({"exp": expire})
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
 


### PR DESCRIPTION
## Summary
- fix deprecation warning by using `datetime.now(UTC)` for token expiration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fef418d5c832f9023fc9972f3bb27