### PR TITLE
Add typed stats data

### DIFF
--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useState } from 'react'
 import { statsOverview } from '../api'
 
+interface StatsData {
+  reviewed: number
+  due: number
+  next_due: string | null
+}
+
 export default function Stats() {
-  const [data, setData] = useState<any>(null)
+  const [data, setData] = useState<StatsData | null>(null)
   useEffect(() => {
     statsOverview().then(setData)
   }, [])


### PR DESCRIPTION
## Summary
- define `StatsData` interface matching backend `StatsOut`
- type the Stats page state with `StatsData | null`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68500b7dbc2c832fb4c7c441217082e2