### PR TITLE
Fix login flow and enable CORS

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, Depends, HTTPException, status, Response
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from fastapi.middleware.cors import CORSMiddleware
 from typing import List
 from jose import JWTError
 import json
@@ -16,6 +17,15 @@ from . import crud
 from .security import create_access_token, decode_token
 
 app = FastAPI(title="Word Cards")
+
+# Allow frontend development server to access the API
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,7 +1,10 @@
 import api from './client'
 
 export const login = async (username: string, password: string) => {
-  const res = await api.post('/auth/login', { username, password })
+  const form = new URLSearchParams()
+  form.append('username', username)
+  form.append('password', password)
+  const res = await api.post('/auth/login', form)
   return res.data
 }
 


### PR DESCRIPTION
## Summary
- enable CORS middleware so the frontend can access the API
- send login credentials as form data instead of JSON

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68501256bd14832faa5e6e654f87c50d