### PR TITLE
Improve Word Cards UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Word Cards</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom'
+import type { PropsWithChildren } from 'react'
+import { useAuth } from '../store/auth'
+
+export default function Layout({ children }: PropsWithChildren) {
+  const setToken = useAuth((s) => s.setToken)
+  const handleLogout = () => setToken(null)
+
+  return (
+    <div className="min-h-screen flex flex-col bg-gray-50">
+      <nav className="bg-gray-800 text-white px-4 py-3 flex gap-4 items-center">
+        <Link className="hover:text-blue-400" to="/study">Study</Link>
+        <Link className="hover:text-blue-400" to="/search">Search</Link>
+        <Link className="hover:text-blue-400" to="/stats">Stats</Link>
+        <Link className="hover:text-blue-400" to="/admin">Admin</Link>
+        <button className="ml-auto hover:text-blue-400" onClick={handleLogout}>
+          Logout
+        </button>
+      </nav>
+      <main className="flex-grow container mx-auto p-4">{children}</main>
+    </div>
+  )
+}

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -1,3 +1,9 @@
+import Layout from '../components/Layout'
+
 export default function Admin() {
-  return <div className="p-4">Admin Page (todo)</div>
+  return (
+    <Layout>
+      <div>Admin Page (todo)</div>
+    </Layout>
+  )
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,11 +1,23 @@
 import { Link } from 'react-router-dom'
+import Layout from '../components/Layout'
+
 export default function Dashboard() {
   return (
-    <div className="p-4 flex flex-col gap-2">
-      <Link className="text-blue-500" to="/study">Start Studying</Link>
-      <Link className="text-blue-500" to="/search">Search</Link>
-      <Link className="text-blue-500" to="/stats">Stats</Link>
-      <Link className="text-blue-500" to="/admin">Admin</Link>
-    </div>
+    <Layout>
+      <div className="grid gap-4 max-w-md mx-auto pt-4">
+        <Link className="border rounded px-4 py-2 shadow bg-blue-500 text-white" to="/study">
+          Start Studying
+        </Link>
+        <Link className="border rounded px-4 py-2 shadow bg-green-500 text-white" to="/search">
+          Search
+        </Link>
+        <Link className="border rounded px-4 py-2 shadow bg-purple-500 text-white" to="/stats">
+          Stats
+        </Link>
+        <Link className="border rounded px-4 py-2 shadow bg-gray-700 text-white" to="/admin">
+          Admin
+        </Link>
+      </div>
+    </Layout>
   )
 }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -19,6 +19,7 @@ export default function Login() {
 
   return (
     <div className="p-4 max-w-sm mx-auto flex flex-col gap-2">
+      <h1 className="text-center text-2xl font-semibold mb-2">Word Cards</h1>
       <input
         className="border p-2"
         placeholder="Username"
@@ -32,10 +33,10 @@ export default function Login() {
         value={password}
         onChange={(e) => setPassword(e.target.value)}
       />
-      <button className="bg-blue-500 text-white p-2" onClick={handleLogin}>
+      <button className="border rounded px-4 py-2 shadow bg-blue-500 text-white" onClick={handleLogin}>
         Login
       </button>
-      <button className="border p-2" onClick={handleRegister}>
+      <button className="border rounded px-4 py-2 shadow bg-white hover:bg-gray-100" onClick={handleRegister}>
         Register
       </button>
     </div>

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { searchWord } from '../api'
 import { Link } from 'react-router-dom'
+import Layout from '../components/Layout'
 
 interface Word {
   id: number
@@ -18,22 +19,28 @@ export default function Search() {
   }
 
   return (
-    <div className="p-4 flex flex-col gap-2">
-      <input
-        className="border p-2"
-        value={q}
-        onChange={(e) => setQ(e.target.value)}
-      />
-      <button className="border p-2" onClick={handleSearch}>
-        Search
-      </button>
-      <ul>
-        {results.map((w) => (
-          <li key={w.id}>
-            <Link className="text-blue-500" to={`/study#${w.id}`}>{w.word_en}</Link>
-          </li>
-        ))}
-      </ul>
-    </div>
+    <Layout>
+      <div className="flex flex-col gap-4 max-w-xl mx-auto">
+        <div className="flex gap-2">
+          <input
+            className="border p-2 flex-grow"
+            placeholder="Search word"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+          />
+          <button className="border rounded px-4 py-2 shadow bg-white hover:bg-gray-100" onClick={handleSearch}>
+            Search
+          </button>
+        </div>
+        <ul className="space-y-2">
+          {results.map((w) => (
+            <li key={w.id} className="p-2 border rounded shadow bg-white">
+              <Link className="text-blue-500 font-semibold" to={`/study#${w.id}`}>{w.word_en}</Link>
+              <div className="text-gray-600">{w.word_zh}</div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </Layout>
   )
 }

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { statsOverview } from '../api'
+import Layout from '../components/Layout'
 
 interface StatsData {
   reviewed: number
@@ -13,8 +14,30 @@ export default function Stats() {
     statsOverview().then(setData)
   }, [])
 
-  if (!data) return <div className="p-4">Loading...</div>
+  if (!data) return (
+    <Layout>
+      <div>Loading...</div>
+    </Layout>
+  )
+
   return (
-    <pre className="p-4 whitespace-pre-wrap">{JSON.stringify(data, null, 2)}</pre>
+    <Layout>
+      <div className="grid sm:grid-cols-3 gap-4 text-center">
+        <div className="shadow rounded p-4 bg-white">
+          <div className="text-2xl font-bold">{data.reviewed}</div>
+          <div className="text-gray-500">Reviewed</div>
+        </div>
+        <div className="shadow rounded p-4 bg-white">
+          <div className="text-2xl font-bold">{data.due}</div>
+          <div className="text-gray-500">Due Today</div>
+        </div>
+        <div className="shadow rounded p-4 bg-white">
+          <div className="text-2xl font-bold">
+            {data.next_due ? new Date(data.next_due).toLocaleDateString() : 'N/A'}
+          </div>
+          <div className="text-gray-500">Next Due</div>
+        </div>
+      </div>
+    </Layout>
   )
 }

--- a/frontend/src/pages/Study.tsx
+++ b/frontend/src/pages/Study.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { fetchToday, reviewWord } from '../api'
+import Layout from '../components/Layout'
 
 interface Word {
   id: number
@@ -25,29 +26,36 @@ export default function Study() {
     setIndex((i) => i + 1)
   }
 
-  if (!current) return <div className="p-4">All done!</div>
+  if (!current)
+    return (
+      <Layout>
+        <div>All done!</div>
+      </Layout>
+    )
 
   return (
-    <div className="p-4 flex flex-col items-center gap-4">
-      <div
-        className="border p-8 text-center w-64 h-40 flex items-center justify-center cursor-pointer"
-        onClick={() => setShowBack((v) => !v)}
-      >
-        {showBack ? current.word_zh : current.word_en}
-      </div>
-      {showBack && (
-        <div className="flex gap-2">
-          {[0, 1, 2, 3, 4, 5].map((q) => (
-            <button
-              key={q}
-              className="border px-2"
-              onClick={() => handleQuality(q)}
-            >
-              {q}
-            </button>
-          ))}
+    <Layout>
+      <div className="flex flex-col items-center gap-4">
+        <div
+          className="border p-8 text-center w-64 h-40 flex items-center justify-center cursor-pointer bg-white shadow rounded"
+          onClick={() => setShowBack((v) => !v)}
+        >
+          {showBack ? current.word_zh : current.word_en}
         </div>
-      )}
-    </div>
+        {showBack && (
+          <div className="flex gap-2">
+            {[0, 1, 2, 3, 4, 5].map((q) => (
+              <button
+                key={q}
+                className="border rounded px-2 shadow"
+                onClick={() => handleQuality(q)}
+              >
+                {q}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </Layout>
   )
 }


### PR DESCRIPTION
## Summary
- create shared Layout component with nav and logout
- restyle dashboard links and add login page heading
- improve search results layout and stats display
- modernize study page buttons
- update page titles

## Testing
- `npm run lint`
- `npm run build`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68501528b350832f89449b1a28ef3243