### PR TITLE
Improve word study workflow and search

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -94,8 +94,8 @@ def get_current_user(token: str = Depends(oauth2_scheme)):
         return user
 
 @app.get("/words/today", response_model=List[WordOut])
-def words_today(current_user: User = Depends(get_current_user)):
-    words = crud.get_due_words(current_user.id)
+def words_today(limit: int | None = None, current_user: User = Depends(get_current_user)):
+    words = crud.get_due_words(current_user.id, limit)
     result = []
     for w in words:
         result.append(WordOut(id=w.id, word=w.word, translations=json.loads(w.translations), phrases=json.loads(w.phrases) if w.phrases else []))

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -81,9 +81,13 @@ function showDashboard() {
 let studyWords = [];
 let studyIndex = 0;
 let showBack = false;
+let dailyCount = 5;
 
 async function showStudy() {
-  studyWords = await api('/words/today');
+  const n = prompt('How many words today? (min 5)', dailyCount);
+  const num = parseInt(n || dailyCount, 10);
+  dailyCount = isNaN(num) ? dailyCount : Math.max(5, num);
+  studyWords = await api('/words/today?limit=' + dailyCount);
   studyIndex = 0;
   showBack = false;
   renderStudy();
@@ -96,19 +100,24 @@ function renderStudy() {
     main.innerHTML = '<div>All done!</div>';
     return;
   }
-  const translation = w.translations.map(t => t.translation).join(', ');
+  const translation = w.translations.map(t => `${t.type || ''} ${t.translation}`).join('<br>');
+  const phrases = w.phrases ? w.phrases.map(p => `${p.phrase} - ${p.translation}`).join('<br>') : '';
+  const back = `<div>${translation}${phrases ? '<hr class="my-2">' + phrases : ''}</div>`;
   main.innerHTML = `
     <div class="flex flex-col items-center gap-4">
-      <div id="card" class="border p-8 text-center w-64 h-40 flex items-center justify-center cursor-pointer bg-white shadow rounded">${showBack ? translation : w.word}</div>
+      <div id="card" class="border p-4 text-center w-72 min-h-40 flex items-center justify-center cursor-pointer bg-white shadow rounded">${showBack ? back : w.word}</div>
       <div id="buttons" class="flex gap-2 ${showBack ? '' : 'hidden'}">
-        ${[0,1,2,3,4,5].map(q => `<button class="border rounded px-2 shadow" data-q="${q}">${q}</button>`).join('')}
+        ${['不认识','模糊','认识'].map((t,i) => `<button class="border rounded px-2 shadow" data-q="${i}">${t}</button>`).join('')}
       </div>
     </div>`;
   document.getElementById('card').onclick = () => { showBack = !showBack; renderStudy(); };
   document.querySelectorAll('#buttons button').forEach(btn => {
     btn.onclick = async () => {
-      await api('/review/' + w.id, { method: 'POST', body: { quality: btn.dataset.q } });
+      const map = [1,3,5];
+      const q = parseInt(btn.dataset.q,10);
+      await api('/review/' + w.id, { method: 'POST', body: { quality: map[q] } });
       showBack = false;
+      if(q < 2) studyWords.push(w);
       studyIndex++;
       renderStudy();
     };
@@ -124,13 +133,50 @@ function showSearch() {
         <button id="go" class="border rounded px-4 py-2 shadow bg-white hover:bg-gray-100">Search</button>
       </div>
       <ul id="results" class="space-y-2"></ul>
+    </div>
+    <div id="modal" class="fixed inset-0 bg-black/50 items-center justify-center hidden">
+      <div class="bg-white p-4 rounded shadow max-w-md w-full">
+        <button id="closeModal" class="float-right">✖</button>
+        <div id="modalContent" class="mt-2"></div>
+      </div>
     </div>`;
-  document.getElementById('go').onclick = async () => {
-    const q = document.getElementById('q').value;
+  const input = document.getElementById('q');
+  const results = document.getElementById('results');
+  let data = [];
+  async function search() {
+    const q = input.value.trim();
+    if(!q) return;
     const res = await api('/search?q=' + encodeURIComponent(q));
-    const list = res.map(w => `<li class="p-2 border rounded shadow bg-white"><span class="text-blue-500 font-semibold">${w.word}</span> <span class="text-gray-600">${w.translations.map(t=>t.translation).join(', ')}</span></li>`).join('');
-    document.getElementById('results').innerHTML = list;
+    data = res;
+    const list = res.map((w,i) => `<li data-i="${i}" class="p-2 border rounded shadow bg-white cursor-pointer"><span class="text-blue-500 font-semibold">${w.word}</span> <span class="text-gray-600">${w.translations.map(t=>t.translation).join(', ')}</span></li>`).join('');
+    results.innerHTML = list;
+  }
+  document.getElementById('go').onclick = search;
+  input.addEventListener('keydown', e => { if(e.key === 'Enter') search(); });
+  results.onclick = (e) => {
+    const li = e.target.closest('li[data-i]');
+    if(!li) return;
+    const w = data[li.dataset.i];
+    showWordModal(w);
   };
+}
+
+function showWordModal(w) {
+  const modal = document.getElementById('modal');
+  const content = document.getElementById('modalContent');
+  content.innerHTML = `
+    <h2 class="text-xl font-bold mb-2">${w.word}</h2>
+    <div>${w.translations.map(t => `<div>${t.type || ''} ${t.translation}</div>`).join('')}</div>
+    ${w.phrases && w.phrases.length ? `<div class="mt-2">${w.phrases.map(p => `<div>${p.phrase} - ${p.translation}</div>`).join('')}</div>` : ''}
+    <button id="speakBtn" class="mt-2 border px-2 rounded bg-white shadow">🔊</button>
+  `;
+  modal.classList.remove('hidden');
+  document.getElementById('speakBtn').onclick = () => speak(w.word);
+  document.getElementById('closeModal').onclick = () => modal.classList.add('hidden');
+}
+
+function speak(text) {
+  window.speechSynthesis.speak(new SpeechSynthesisUtterance(text));
 }
 
 async function showStats() {


### PR DESCRIPTION
## Summary
- persist newly created users into a `users.json` file for easy recovery
- allow optional `limit` when requesting today's words
- show richer info during study and map review to three choices
- add daily word count prompt and repeat unknown words
- enhance search UI with modal details and speech synthesis

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850bd6d0db8832f92b2dcba65e82bf7