### PR TITLE
Add settings page and new user endpoints

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -23,3 +23,17 @@ class StatsOut(BaseModel):
     reviewed: int
     due: int
     next_due: Optional[date] = None
+
+
+class UserOut(BaseModel):
+    id: int
+    username: str
+    role: str
+
+
+class UserUpdate(BaseModel):
+    username: str
+
+
+class PasswordUpdate(BaseModel):
+    password: str


### PR DESCRIPTION
## Summary
- add API endpoints for retrieving and updating current user
- add new password update route
- make daily word count persistent and configurable
- add Settings UI with daily count, username and password
- fix All done message when no words are available

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c81936a0832f8b42c0bb760a63d7