### PR TITLE
Fix daily words limit logic

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -55,7 +55,7 @@ def get_due_words(user_id: int, limit: int | None = None):
         for word, review in session.exec(statement).all():
             if not review or review.next_review <= today:
                 words.append(word)
-        if limit:
+        if limit is not None:
             words = words[:limit]
         return words
 


### PR DESCRIPTION
## Summary
- enforce daily word limit when serving study words
- respect daily limit in stats overview
- support limit=0 in `get_due_words`
- test daily limit enforcement

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850e1328980832f84b68e5d9bd808b5