### PR TITLE
Refactor frontend into multi-page layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This project contains a small FastAPI backend and tests for a vocabulary learnin
 
 The frontend is a simple static site located in `frontend/`.
 Open `frontend/index.html` in a browser or serve the directory with any HTTP server.
+`index.html` now redirects to either `login.html` or `dashboard.html` depending on
+whether a token exists in `localStorage`.
 It uses Tailwind CSS via CDN and communicates with the FastAPI backend running on
 `http://localhost:8000`.
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Word Cards</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50">
+  <nav class="bg-gray-800 text-white px-4 py-3 flex gap-4 items-center">
+    <button id="study" class="hover:text-blue-400">Study</button>
+    <button id="search" class="hover:text-blue-400">Search</button>
+    <button id="stats" class="hover:text-blue-400">Stats</button>
+    <button id="settings" class="hover:text-blue-400">Settings</button>
+    <button id="logout" class="ml-auto hover:text-blue-400">Logout</button>
+  </nav>
+  <main id="main" class="p-4"></main>
+  <script src="js/common.js"></script>
+  <script src="js/dashboard.js"></script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,9 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Word Cards</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    if (localStorage.getItem('token')) {
+      window.location.href = 'dashboard.html';
+    } else {
+      window.location.href = 'login.html';
+    }
+  </script>
 </head>
-<body class="bg-gray-50">
-  <script src="script.js"></script>
+<body>
 </body>
 </html>

--- a/frontend/js/common.js
+++ b/frontend/js/common.js
@@ -1,0 +1,16 @@
+const API_URL = 'http://localhost:8000';
+
+function api(path, options = {}) {
+  options.headers = options.headers || {};
+  const token = localStorage.getItem('token');
+  if (token) options.headers['Authorization'] = 'Bearer ' + token;
+  if (options.body && !(options.body instanceof FormData)) {
+    options.headers['Content-Type'] = 'application/json';
+    options.body = JSON.stringify(options.body);
+  }
+  return fetch(API_URL + path, options).then(async (res) => {
+    if (!res.ok) throw new Error(await res.text());
+    const ct = res.headers.get('content-type');
+    return ct && ct.includes('application/json') ? res.json() : res.text();
+  });
+}

--- a/frontend/js/login.js
+++ b/frontend/js/login.js
@@ -1,0 +1,40 @@
+function loginRequest(username, password) {
+  const form = new URLSearchParams();
+  form.append('username', username);
+  form.append('password', password);
+  return fetch(API_URL + '/auth/login', { method: 'POST', body: form })
+    .then(res => res.ok ? res.json() : Promise.reject());
+}
+
+function registerRequest(username, password) {
+  return api('/auth/register', { method: 'POST', body: { username, password } });
+}
+
+function init() {
+  document.getElementById('login').onclick = async () => {
+    const u = document.getElementById('user').value;
+    const p = document.getElementById('pwd').value;
+    try {
+      const data = await loginRequest(u, p);
+      localStorage.setItem('token', data.access_token);
+      window.location.href = 'dashboard.html';
+    } catch {
+      document.getElementById('msg').textContent = 'Login failed';
+    }
+  };
+
+  document.getElementById('register').onclick = async () => {
+    const u = document.getElementById('user').value;
+    const p = document.getElementById('pwd').value;
+    try {
+      await registerRequest(u, p);
+      const data = await loginRequest(u, p);
+      localStorage.setItem('token', data.access_token);
+      window.location.href = 'dashboard.html';
+    } catch {
+      document.getElementById('msg').textContent = 'Register failed';
+    }
+  };
+}
+
+window.addEventListener('DOMContentLoaded', init);

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Word Cards - Login</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50">
+  <div class="p-4 max-w-sm mx-auto flex flex-col gap-2">
+    <h1 class="text-center text-2xl font-semibold mb-2">Word Cards</h1>
+    <input id="user" class="border p-2" placeholder="Username">
+    <input id="pwd" class="border p-2" type="password" placeholder="Password">
+    <button id="login" class="border rounded px-4 py-2 shadow bg-blue-500 text-white">Login</button>
+    <button id="register" class="border rounded px-4 py-2 shadow bg-white hover:bg-gray-100">Register</button>
+    <div id="msg" class="text-red-600"></div>
+  </div>
+  <script src="js/common.js"></script>
+  <script src="js/login.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- split SPA frontend into login and dashboard pages
- add common API helper
- update README with new frontend structure

## Testing
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6851fe4ec7e8832fb609ed123ef96da4