### PR TITLE
Improve translation page integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Open `frontend/index.html` in a browser or serve the directory with any HTTP ser
 whether a token exists in `localStorage`.
 It uses Tailwind CSS via CDN and communicates with the FastAPI backend running on
 `http://localhost:8000`.
-The dashboard navigation now includes a link to `translate.html` which provides a simple translation interface.
+The dashboard navigation includes a link to `translate.html`. The translation page
+now shares the same Tailwind based styling and provides navigation back to the dashboard.
 
 ## Running tests
 

--- a/frontend/js/translate.js
+++ b/frontend/js/translate.js
@@ -1,9 +1,25 @@
 function init() {
+  if (!localStorage.getItem('token')) {
+    window.location.href = 'login.html';
+    return;
+  }
+
   const btn = document.getElementById('btnTranslate');
   const input = document.getElementById('inputText');
   const output = document.getElementById('outputText');
   const langSel = document.getElementById('targetLang');
   const loading = document.getElementById('loading');
+
+  const backBtn = document.getElementById('dashboard');
+  const logoutBtn = document.getElementById('logout');
+
+  backBtn.onclick = () => {
+    window.location.href = 'dashboard.html';
+  };
+  logoutBtn.onclick = () => {
+    localStorage.removeItem('token');
+    window.location.href = 'login.html';
+  };
 
   btn.onclick = async () => {
     const text = input.value.trim();

--- a/frontend/translate.html
+++ b/frontend/translate.html
@@ -2,14 +2,18 @@
 <html lang="zh-CN">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Translation</title>
-  <script src="https://cdn.jsdelivr.net/npm/twind@0.16.17/twind.min.js"></script>
-  <script>window.twind.setup();</script>
+  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 min-h-screen flex items-center justify-center p-4">
-  <div class="bg-white rounded-2xl shadow-md p-6 w-full max-w-lg">
-    <h1 class="text-2xl font-semibold mb-4 text-center">通用翻译</h1>
+<body class="bg-gray-50">
+  <nav class="bg-gray-800 text-white px-4 py-3 flex gap-4 items-center">
+    <button id="dashboard" class="hover:text-blue-400">Dashboard</button>
+    <button id="logout" class="ml-auto hover:text-blue-400">Logout</button>
+  </nav>
+  <main class="p-4">
+    <div class="bg-white rounded shadow p-6 w-full max-w-lg mx-auto">
+      <h1 class="text-2xl font-semibold mb-4 text-center">通用翻译</h1>
 
     <label class="block mb-2">
       <span class="text-gray-700">目标语言：</span>
@@ -51,7 +55,8 @@
       <textarea id="outputText" rows="6" readonly
         class="mt-1 block w-full rounded-lg border-gray-300 p-2 bg-gray-50"></textarea>
     </label>
-  </div>
+    </div>
+  </main>
 
   <script src="js/common.js"></script>
   <script src="js/translate.js"></script>


### PR DESCRIPTION
## Summary
- rework `translate.html` to use Tailwind and include navigation
- add navigation and auth check logic in `translate.js`
- update README to note translation page styling

## Testing
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852111a2450832fb872ce18386155a1