### PR TITLE
Add wordbook selection and advanced study flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ It uses Tailwind CSS via CDN and communicates with the FastAPI backend running o
 The dashboard navigation includes a link to `translate.html`. The translation page
 now shares the same Tailwind based styling and provides navigation back to the dashboard.
 
+Word books are stored as JSON files under the `wordbooks/` directory using the naming
+scheme `wordBook_<NAME>.json`.
+
 ## Running tests
 
 Use `pytest` with the repository root on the Python path so that

--- a/wordbooks/wordBook_TEST.json
+++ b/wordbooks/wordBook_TEST.json
@@ -1,0 +1,256 @@
+[
+  {
+    "word": "abruptly",
+    "translations": [
+      {
+        "translation": "突然地",
+        "type": "adv"
+      }
+    ]
+  },
+  {
+    "word": "absorb",
+    "translations": [
+      {
+        "translation": "吸收（液体、气体等）",
+        "type": "v"
+      }
+    ],
+    "phrases": [
+      {
+        "phrase": "absorb in",
+        "translation": "集中精力做某事；全神贯注于"
+      }
+    ]
+  },
+  {
+    "word": "abuse",
+    "translations": [
+      {
+        "translation": "滥用，虐待",
+        "type": "v"
+      }
+    ],
+    "phrases": [
+      {
+        "phrase": "drug abuse",
+        "translation": "药物滥用；毒品滥用"
+      },
+      {
+        "phrase": "child abuse",
+        "translation": "虐待儿童，摧残儿童"
+      },
+      {
+        "phrase": "substance abuse",
+        "translation": "物质滥用；滥用药物"
+      },
+      {
+        "phrase": "sexual abuse",
+        "translation": "性虐待"
+      },
+      {
+        "phrase": "abuse of power",
+        "translation": "滥用权力"
+      },
+      {
+        "phrase": "alcohol abuse",
+        "translation": "酒精滥用，酗酒"
+      },
+      {
+        "phrase": "physical abuse",
+        "translation": "躯体虐待；身体伤害；外观损坏"
+      },
+      {
+        "phrase": "verbal abuse",
+        "translation": "言语虐待；口头谩骂；说粗话，用污言秽语"
+      },
+      {
+        "phrase": "sex abuse",
+        "translation": "性虐待（等于sexual abuse）"
+      },
+      {
+        "phrase": "emotional abuse",
+        "translation": "精神虐待"
+      }
+    ]
+  },
+  {
+    "word": "academic",
+    "translations": [
+      {
+        "translation": "学校(院)的，学术的",
+        "type": "adj"
+      }
+    ],
+    "phrases": [
+      {
+        "phrase": "academic research",
+        "translation": "学术研究"
+      },
+      {
+        "phrase": "academic circles",
+        "translation": "学术界"
+      },
+      {
+        "phrase": "academic year",
+        "translation": "学年"
+      },
+      {
+        "phrase": "academic achievement",
+        "translation": "学业成就；学业成绩"
+      },
+      {
+        "phrase": "academic performance",
+        "translation": "学习成绩；学业表现；学术成就"
+      },
+      {
+        "phrase": "academic study",
+        "translation": "学术研究"
+      },
+      {
+        "phrase": "academic exchange",
+        "translation": "学术交流"
+      },
+      {
+        "phrase": "academic problem",
+        "translation": "学术问题"
+      },
+      {
+        "phrase": "academic background",
+        "translation": "学术背景；学历；教育背景"
+      },
+      {
+        "phrase": "academic world",
+        "translation": "学术界"
+      }
+    ]
+  },
+  {
+    "word": "access",
+    "translations": [
+      {
+        "translation": "获取",
+        "type": "v"
+      },
+      {
+        "translation": "接近，入口",
+        "type": "n"
+      }
+    ],
+    "phrases": [
+      {
+        "phrase": "access control",
+        "translation": "访问控制"
+      },
+      {
+        "phrase": "have access to",
+        "translation": "使用；接近；可以利用"
+      },
+      {
+        "phrase": "internet access",
+        "translation": "互联网接入"
+      },
+      {
+        "phrase": "easy access",
+        "translation": "便于检修；容易接近"
+      },
+      {
+        "phrase": "market access",
+        "translation": "市场准入；进入市场；开放市场"
+      },
+      {
+        "phrase": "data access",
+        "translation": "数据存取"
+      },
+      {
+        "phrase": "multiple access",
+        "translation": "[电脑]多路存取；多路访问"
+      },
+      {
+        "phrase": "open access",
+        "translation": "开放存取；开架阅览"
+      },
+      {
+        "phrase": "direct access",
+        "translation": "[计]直接存取"
+      },
+      {
+        "phrase": "access network",
+        "translation": "接入网；接取网络"
+      }
+    ]
+  },
+  {
+    "word": "accessible",
+    "translations": [
+      {
+        "translation": "易接近的",
+        "type": "adj"
+      }
+    ],
+    "phrases": [
+      {
+        "phrase": "readily accessible",
+        "translation": "易接近的；易达到的；可存取的"
+      }
+    ]
+  },
+  {
+    "word": "accommodate",
+    "translations": [
+      {
+        "translation": "适合， 提供住宿",
+        "type": "v"
+      }
+    ],
+    "phrases": [
+      {
+        "phrase": "accommodate with",
+        "translation": "向…供应；提供；以…供应"
+      }
+    ]
+  },
+  {
+    "word": "accomplish",
+    "translations": [
+      {
+        "translation": "完成",
+        "type": "v"
+      }
+    ],
+    "phrases": [
+      {
+        "phrase": "accomplish nothing",
+        "translation": "一事无成；一无所成"
+      }
+    ]
+  },
+  {
+    "word": "accumulate",
+    "translations": [
+      {
+        "translation": "积累，增加",
+        "type": "v"
+      }
+    ]
+  },
+  {
+    "word": "accurate",
+    "translations": [
+      {
+        "translation": "精确的，准确的",
+        "type": "adj"
+      }
+    ],
+    "phrases": [
+      {
+        "phrase": "accurate measurement",
+        "translation": "精确测量"
+      },
+      {
+        "phrase": "accurate positioning",
+        "translation": "精确定位"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- enhance study card logic with fuzzy review and continue buttons
- allow choosing word books from new `wordbooks/` folder
- expose `/wordbooks` API endpoint and load default book on startup
- document word book storage

## Testing
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521e93ec28832fb9f8099c3aeafdbc