### PR TITLE
Add frontend wordbook switching with local progress

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -219,6 +219,17 @@ def list_wordbooks():
                 books.append(fn[len("wordBook_"):-5])
     return books
 
+
+@app.get("/wordbook/{name}")
+def get_wordbook(name: str):
+    """Return the raw word list for the given word book."""
+    filename = os.path.join(WORDBOOK_DIR, f"wordBook_{name}.json")
+    if not os.path.exists(filename):
+        raise HTTPException(status_code=404, detail="Word book not found")
+    with open(filename, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data
+
 @app.get("/admin/users")
 def admin_users(current_user: User = Depends(get_current_user)):
     if current_user.role != "admin":


### PR DESCRIPTION
## Summary
- serve raw wordbook data via `/wordbook/{name}`
- load selected word book on the dashboard and keep per-book progress in localStorage
- update study view to advance progress locally when a word is recognised

## Testing
- `pip install -q fastapi httpx sqlmodel sqlalchemy pytest python-jose bcrypt passlib python-multipart`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685221a94734832fbde71d16b21afe60