### PR TITLE
Add admin dashboard

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin Panel</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50">
+  <nav class="bg-gray-800 text-white px-4 py-3 flex gap-4 items-center">
+    <button id="users" class="hover:text-blue-400">Users</button>
+    <button id="logout" class="ml-auto hover:text-blue-400">Logout</button>
+  </nav>
+  <main id="main" class="p-4"></main>
+  <script src="js/common.js"></script>
+  <script src="js/admin.js"></script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,12 +4,28 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Word Cards</title>
-  <script>
-    if (localStorage.getItem('token')) {
-      window.location.href = 'dashboard.html';
-    } else {
-      window.location.href = 'login.html';
+  <script type="module">
+    const token = localStorage.getItem('token');
+    async function go() {
+      if (!token) {
+        window.location.href = 'login.html';
+        return;
+      }
+      try {
+        const res = await fetch('http://localhost:8000/users/me', {
+          headers: { Authorization: 'Bearer ' + token }
+        });
+        if (!res.ok) throw new Error();
+        const user = await res.json();
+        localStorage.setItem('role', user.role);
+        window.location.href = user.role === 'admin' ? 'admin.html' : 'dashboard.html';
+      } catch {
+        localStorage.removeItem('token');
+        localStorage.removeItem('role');
+        window.location.href = 'login.html';
+      }
     }
+    go();
   </script>
 </head>
 <body>

--- a/frontend/js/admin.js
+++ b/frontend/js/admin.js
@@ -1,0 +1,53 @@
+function logout() {
+  localStorage.removeItem('token');
+  localStorage.removeItem('role');
+  window.location.href = 'login.html';
+}
+
+async function loadUsers() {
+  try {
+    const data = await api('/admin/users');
+    const rows = data.map(u => `<tr>
+      <td class="border px-2">${u.id}</td>
+      <td class="border px-2">${u.username}</td>
+      <td class="border px-2">${u.role}</td>
+      <td class="border px-2 text-center"><button data-id="${u.id}" class="reset bg-blue-500 text-white px-2 rounded">Reset</button></td>
+    </tr>`).join('');
+    document.getElementById('main').innerHTML = `
+      <table class="table-auto w-full bg-white shadow rounded">
+        <thead><tr><th class="border px-2">ID</th><th class="border px-2">Username</th><th class="border px-2">Role</th><th class="border px-2">Actions</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+      <div id="msg" class="text-green-600 mt-2"></div>`;
+    document.querySelectorAll('button.reset').forEach(btn => {
+      btn.onclick = async () => {
+        const pwd = prompt('New password:');
+        if (!pwd) return;
+        try {
+          await api(`/admin/users/${btn.dataset.id}/reset_pwd?password=${encodeURIComponent(pwd)}`, { method: 'PUT' });
+          document.getElementById('msg').textContent = 'Password reset';
+        } catch {
+          document.getElementById('msg').textContent = 'Error';
+        }
+      };
+    });
+  } catch {
+    document.getElementById('main').textContent = 'Failed to load users';
+  }
+}
+
+function init() {
+  if (!localStorage.getItem('token')) {
+    window.location.href = 'login.html';
+    return;
+  }
+  if (localStorage.getItem('role') !== 'admin') {
+    window.location.href = 'dashboard.html';
+    return;
+  }
+  document.getElementById('logout').onclick = logout;
+  document.getElementById('users').onclick = loadUsers;
+  loadUsers();
+}
+
+window.addEventListener('DOMContentLoaded', init);

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -272,6 +272,10 @@ function init() {
     window.location.href = 'login.html';
     return;
   }
+  if (localStorage.getItem('role') === 'admin') {
+    window.location.href = 'admin.html';
+    return;
+  }
   document.getElementById('logout').onclick = logout;
   document.getElementById('study').onclick = showStudy;
   document.getElementById('search').onclick = showSearch;

--- a/frontend/js/login.js
+++ b/frontend/js/login.js
@@ -6,6 +6,17 @@ function loginRequest(username, password) {
     .then(res => res.ok ? res.json() : Promise.reject());
 }
 
+async function afterAuth(token) {
+  localStorage.setItem('token', token);
+  try {
+    const me = await api('/users/me');
+    localStorage.setItem('role', me.role);
+    window.location.href = me.role === 'admin' ? 'admin.html' : 'dashboard.html';
+  } catch {
+    document.getElementById('msg').textContent = 'Login failed';
+  }
+}
+
 function registerRequest(username, password) {
   return api('/auth/register', { method: 'POST', body: { username, password } });
 }
@@ -16,8 +27,7 @@ function init() {
     const p = document.getElementById('pwd').value;
     try {
       const data = await loginRequest(u, p);
-      localStorage.setItem('token', data.access_token);
-      window.location.href = 'dashboard.html';
+      await afterAuth(data.access_token);
     } catch {
       document.getElementById('msg').textContent = 'Login failed';
     }
@@ -29,8 +39,7 @@ function init() {
     try {
       await registerRequest(u, p);
       const data = await loginRequest(u, p);
-      localStorage.setItem('token', data.access_token);
-      window.location.href = 'dashboard.html';
+      await afterAuth(data.access_token);
     } catch {
       document.getElementById('msg').textContent = 'Register failed';
     }


### PR DESCRIPTION
## Summary
- add a dedicated admin page and script
- redirect based on role after login or on index load
- prevent admin from using regular dashboard
- include simple user list with password reset

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685363bffde0832fa58f6752f9c5290d