### PR TITLE
Add env template for secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to .env and fill in the values
+# Example configuration for Word Cards
+SECRET_KEY=your-secret-key
+TRANSLATE_API_KEY=your-translate-api-key
+# Uncomment to specify which wordbook JSON to load by default
+# WORDBOOK_NAME=TEST

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 **/__pycache__/
 users.json
 wordbooks/wordBook_CET4.json
+
+.env

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ This project contains a small FastAPI backend and tests for a vocabulary learnin
 - `SECRET_KEY` – signing key used for JWT tokens. If the environment variable is unset the application defaults to `"secret"`. Override it in production for better security.
 - `TRANSLATE_API_KEY` – API key for the external translation service used by the `/translate` endpoint.
 
+Create a `.env` file in the project root to provide these variables during development. A template is available as `.env.example`:
+
+```bash
+cp .env.example .env
+# then edit .env and set the values
+```
+
 ## Frontend
 
 The frontend is a simple static site located in `frontend/`.


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders
- document `.env` usage in README
- ignore `.env` in `.gitignore`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68537b685838832faf72884f8a73c74c