### PR TITLE
Add .env template and dotenv loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and fill in your own values
+SECRET_KEY=your-secret-key
+TRANSLATE_API_KEY=your-translation-api-key

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This project contains a small FastAPI backend and tests for a vocabulary learnin
 ## Configuration
 
 - `SECRET_KEY` – signing key used for JWT tokens. If the environment variable is unset the application defaults to `"secret"`. Override it in production for better security.
-- `TRANSLATE_API_KEY` – API key for the external translation service used by the `/translate` endpoint.
+- `TRANSLATE_API_KEY` – API key for the external translation service used by the `/translate` and `/generate_article` endpoints. These features will return an error if the key is not provided.
 
-Create a `.env` file in the project root to provide these variables during development. A template is available as `.env.example`:
+Create a `.env` file in the project root to provide these variables during development. A template is available as `.env.example`. The file should define `SECRET_KEY` and `TRANSLATE_API_KEY`:
 
 ```bash
 cp .env.example .env

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from jose import JWTError
 import json
 import os
+from dotenv import load_dotenv
 import csv
 import io
 import asyncio
@@ -29,6 +30,9 @@ from .schemas import (
 )
 from . import crud, security
 from .security import create_access_token, decode_token
+
+# Load variables from a local .env file if present
+load_dotenv()
 
 app = FastAPI(title="Word Cards")
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ pytest
 python-jose[cryptography]
 httpx<0.27
 python-multipart
+python-dotenv


### PR DESCRIPTION
## Summary
- add `.env.example` as a sample configuration file
- document required environment variables in README
- load variables from `.env` using python-dotenv
- add `python-dotenv` to backend requirements

## Testing
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68538109b9fc832f9e8cafd7ec687bf6