### PR TITLE
Switch article generation to OpenAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # Copy this file to .env and fill in your own values
 SECRET_KEY=your-secret-key
 TRANSLATE_API_KEY=your-translation-api-key
+OPENAI_API_KEY=your-openai-api-key

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ This project contains a small FastAPI backend and tests for a vocabulary learnin
 ## Configuration
 
 - `SECRET_KEY` – signing key used for JWT tokens. If the environment variable is unset the application defaults to `"secret"`. Override it in production for better security.
-- `TRANSLATE_API_KEY` – API key for the external translation service used by the `/translate` and `/generate_article` endpoints. These features will return an error if the key is not provided.
+- `TRANSLATE_API_KEY` – API key for the external translation service used by the `/translate` endpoint. The feature will return an error if the key is not provided.
+- `OPENAI_API_KEY` – API key for the OpenAI service used by the `/generate_article` endpoint.
 
-Create a `.env` file in the project root to provide these variables during development. A template is available as `.env.example`. The file should define `SECRET_KEY` and `TRANSLATE_API_KEY`:
+Create a `.env` file in the project root to provide these variables during development. A template is available as `.env.example`. The file should define `SECRET_KEY`, `TRANSLATE_API_KEY` and `OPENAI_API_KEY`:
 
 ```bash
 cp .env.example .env


### PR DESCRIPTION
## Summary
- integrate OPENAI_API_KEY and URL for article generation
- update `/generate_article` endpoint to use `gpt-4o-mini`
- document new variable in README and `.env.example`

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68539f6452a4832fbcdf81e3e2e54e06