### PR TITLE
Add MySQL support and initialization script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # Copy this file to .env and fill in your own values
 SECRET_KEY=your-secret-key
 TRANSLATE_API_KEY=your-translation-api-key
+DATABASE_URL=mysql+pymysql://root:111111@localhost/Word_Cards

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ cp .env.example .env
 # then edit .env and set the values
 ```
 
+The backend now uses **MySQL** for data storage. By default it connects to a
+database named `Word_Cards` on `localhost` using the user `root` with the
+password `111111`. You can override this by setting the `DATABASE_URL`
+environment variable.
+
 ## Frontend
 
 The frontend is a simple static site located in `frontend/`.

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,6 +1,10 @@
+import os
 from sqlmodel import SQLModel, create_engine, Session
 
-DATABASE_URL = "sqlite:///./wordcards.db"
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL",
+    "mysql+pymysql://root:111111@/Word_Cards?unix_socket=/tmp/mysql.sock",
+)
 engine = create_engine(DATABASE_URL, echo=False)
 
 def init_db():

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ python-jose[cryptography]
 httpx<0.27
 python-multipart
 python-dotenv
+pymysql

--- a/mysql/init.sql
+++ b/mysql/init.sql
@@ -1,0 +1,46 @@
+CREATE DATABASE IF NOT EXISTS `Word_Cards` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE `Word_Cards`;
+
+ALTER USER 'root'@'localhost' IDENTIFIED BY '111111';
+
+CREATE TABLE IF NOT EXISTS `user` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `username` VARCHAR(255) NOT NULL UNIQUE,
+  `hashed_password` VARCHAR(255) NOT NULL,
+  `role` VARCHAR(50) NOT NULL DEFAULT 'user'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `word` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `word` VARCHAR(255) NOT NULL,
+  `translations` TEXT NOT NULL,
+  `phrases` TEXT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `reviewlog` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `user_id` INT NOT NULL,
+  `word_id` INT NOT NULL,
+  `quality` INT NOT NULL,
+  `last_interval` INT NOT NULL,
+  `next_review` DATE NOT NULL,
+  `reviewed_at` DATETIME NOT NULL,
+  FOREIGN KEY (`user_id`) REFERENCES `user`(`id`),
+  FOREIGN KEY (`word_id`) REFERENCES `word`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `deletionrequest` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `user_id` INT NOT NULL,
+  `requested_at` DATETIME NOT NULL,
+  FOREIGN KEY (`user_id`) REFERENCES `user`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `favorite` (
+  `id` INT AUTO_INCREMENT PRIMARY KEY,
+  `user_id` INT NOT NULL,
+  `word_id` INT NOT NULL,
+  FOREIGN KEY (`user_id`) REFERENCES `user`(`id`),
+  FOREIGN KEY (`word_id`) REFERENCES `word`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+


### PR DESCRIPTION
## Summary
- switch database configuration to MySQL
- add PyMySQL dependency
- describe MySQL usage in README
- include DATABASE_URL in `.env.example`
- provide `mysql/init.sql` to create tables

## Testing
- `pip install -r backend/requirements.txt`
- `DATABASE_URL=sqlite:///./test.db pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b2d6e3e0832fae8c7c2b6fa1c9a3