### PR TITLE
Add common password validator

### DIFF
--- a/frontend/js/common.js
+++ b/frontend/js/common.js
@@ -23,3 +23,9 @@ function api(path, options = {}) {
     return ct && ct.includes('application/json') ? res.json() : res.text();
   });
 }
+
+function validatePassword(pwd) {
+  return /^[A-Za-z0-9]{6,}$/.test(pwd)
+    ? ''
+    : '密码不能为空, 不能含特殊字符且至少6位';
+}

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -413,8 +413,9 @@ function showSettings() {
     try {
       if (username) await api('/users/me', { method: 'PUT', body: { username } });
       if (oldPwd && newPwd) {
-        if (!/^[A-Za-z0-9]{6,}$/.test(newPwd)) {
-          document.getElementById('settingsMsg').textContent = '密码不能为空, 不能含特殊字符且至少6位';
+        const err = validatePassword(newPwd);
+        if (err) {
+          document.getElementById('settingsMsg').textContent = err;
           return;
         }
         await api('/users/me/password', { method: 'PUT', body: { old_password: oldPwd, new_password: newPwd } });

--- a/frontend/js/login.js
+++ b/frontend/js/login.js
@@ -25,8 +25,9 @@ function init() {
   document.getElementById('login').onclick = async () => {
     const u = document.getElementById('user').value;
     const p = document.getElementById('pwd').value;
-    if (!/^[A-Za-z0-9]{6,}$/.test(p)) {
-      document.getElementById('msg').textContent = '密码不能为空, 不能含特殊字符且至少6位';
+    const err = validatePassword(p);
+    if (err) {
+      document.getElementById('msg').textContent = err;
       return;
     }
     try {
@@ -40,8 +41,9 @@ function init() {
   document.getElementById('register').onclick = async () => {
     const u = document.getElementById('user').value;
     const p = document.getElementById('pwd').value;
-    if (!/^[A-Za-z0-9]{6,}$/.test(p)) {
-      document.getElementById('msg').textContent = '密码不能为空, 不能含特殊字符且至少6位';
+    const err = validatePassword(p);
+    if (err) {
+      document.getElementById('msg').textContent = err;
       return;
     }
     try {


### PR DESCRIPTION
## Summary
- add `validatePassword` helper in `frontend/js/common.js`
- use the helper in login and dashboard scripts to avoid repeated regex and message

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6854cd72aab0832f8649a95487fc823c