### PR TITLE
Fix text orientation when flipping cards

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -53,9 +53,25 @@ body {
 }
 
 .flip-card {
+  perspective: 1000px;
+}
+.flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
   transition: transform 0.6s;
   transform-style: preserve-3d;
 }
-.flip-card.flip {
+.flip-card-inner.flip {
+  transform: rotateY(180deg);
+}
+.flip-card-front,
+.flip-card-back {
+  backface-visibility: hidden;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+.flip-card-back {
   transform: rotateY(180deg);
 }

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -103,7 +103,12 @@ function renderStudy() {
   main.innerHTML = `
     <div class="flex flex-col items-center gap-4 min-h-screen">
       <div class="relative">
-        <div id="card" class="flip-card border p-4 text-center w-80 h-48 overflow-y-auto flex items-center justify-center cursor-pointer bg-white shadow rounded ${showBack ? 'flip' : ''}">${showBack ? back : front}</div>
+        <div id="card" class="flip-card w-80 h-48 cursor-pointer">
+          <div class="flip-card-inner ${showBack ? 'flip' : ''}">
+            <div class="flip-card-front border p-4 text-center w-80 h-48 overflow-y-auto flex items-center justify-center bg-white shadow rounded">${front}</div>
+            <div class="flip-card-back border p-4 text-center w-80 h-48 overflow-y-auto flex items-center justify-center bg-white shadow rounded">${back}</div>
+          </div>
+        </div>
         <button id="favStudyBtn" class="absolute top-2 right-2 border px-2 rounded ${favClass}">${favText}</button>
       </div>
       <div id="buttons" class="flex gap-2 fixed bottom-4 left-1/2 -translate-x-1/2">
@@ -113,11 +118,11 @@ function renderStudy() {
         }).join('')}
       </div>
     </div>`;
-  const cardEl = document.getElementById('card');
-  cardEl.onclick = () => {
-    cardEl.classList.toggle('flip');
+  const cardOuter = document.getElementById('card');
+  const cardInner = cardOuter.querySelector('.flip-card-inner');
+  cardOuter.onclick = () => {
+    cardInner.classList.toggle('flip');
     showBack = !showBack;
-    setTimeout(() => { cardEl.innerHTML = showBack ? back : front; }, 300);
   };
   const favBtn = document.getElementById('favStudyBtn');
   favBtn.onclick = async () => {


### PR DESCRIPTION
## Summary
- implement front/back structure for flash cards
- adjust flip logic to swap sides without mirroring text
- add CSS for new flip-card design

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6854d4dee568832f96de504331707373