### PR TITLE
Update front-end API paths

### DIFF
--- a/frontend/js/admin.js
+++ b/frontend/js/admin.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', loadUsers);
 async function loadUsers() {
   const tbody = document.getElementById('user-table-body');
   try {
-    const users = await apiRequest('/api/admin/users');
+    const users = await apiRequest('/admin/users');
     tbody.innerHTML = '';
     users.forEach(u => {
       const tr = document.createElement('tr');
@@ -36,13 +36,13 @@ async function loadUsers() {
 async function resetUser(e) {
   if (!confirm('确定重置此用户数据？')) return;
   const id = e.target.dataset.id;
-  await apiRequest(`/api/admin/users/${id}/reset`, { method: 'POST' });
+  await apiRequest(`/admin/users/${id}/reset`, { method: 'POST' });
   alert('已重置');
 }
 
 async function deleteUser(e) {
   if (!confirm('确定删除此用户？')) return;
   const id = e.target.dataset.id;
-  await apiRequest(`/api/admin/users/${id}`, { method: 'DELETE' });
+  await apiRequest(`/admin/users/${id}`, { method: 'DELETE' });
   loadUsers();
 }

--- a/frontend/js/common.js
+++ b/frontend/js/common.js
@@ -23,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function loadWord() {
     try {
-      const data = await apiRequest('/api/words/review');
+      const data = await apiRequest('/words/review');
       front.textContent = data.word;
       back.textContent = data.translation;
       inner.classList.remove('flipped');

--- a/frontend/js/dashboard.js
+++ b/frontend/js/dashboard.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('stats-container');
   try {
-    const stats = await apiRequest('/api/stats');
+    const stats = await apiRequest('/stats/overview');
     container.innerHTML = `
       <p class="text-lg mb-2">今日复习：${stats.reviewed}/${stats.total}</p>
       <p class="text-lg">正确率：${stats.accuracy}%</p>

--- a/frontend/js/login.js
+++ b/frontend/js/login.js
@@ -4,11 +4,11 @@ form.addEventListener('submit', async e => {
   const u = form.username.value;
   const p = form.password.value;
   try {
-    const data = await apiRequest('/api/auth/login', {
+    const data = await apiRequest('/auth/login', {
       method: 'POST',
       body: JSON.stringify({ username: u, password: p })
     });
-    localStorage.setItem('token', data.token);
+    localStorage.setItem('token', data.access_token);
     window.location.href = 'index.html';
   } catch {
     alert('登陆失败，请检查用户名或密码');


### PR DESCRIPTION
## Summary
- fix the login page to hit `/auth/login` and store `access_token`
- update JavaScript fetch URLs to match backend routes

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854d97b0e10832fb16ea1032778f282