### PR TITLE
Fix admin login

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Open `frontend/login.html` in a browser or serve the directory with any HTTP ser
 After logging in you can study words on `index.html` or view your progress on `dashboard.html`.
 All pages use Tailwind CSS via CDN and communicate with the FastAPI backend running on `http://localhost:8000`.
 
+The backend creates a default administrator account on first run. Use the
+credentials **Admin** / **88888888** to log in and access the admin panel at
+`frontend/admin.html`.
+
 Word books are stored as JSON files under the `wordbooks/` directory using the naming
 scheme `wordBook_<NAME>.json`.
 

--- a/frontend/js/login.js
+++ b/frontend/js/login.js
@@ -6,9 +6,10 @@ form.addEventListener('submit', async e => {
   try {
     const data = await apiRequest('/auth/login', {
       method: 'POST',
-      body: JSON.stringify({ username: u, password: p })
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ username: u, password: p })
     });
-    localStorage.setItem('token', data.token);
+    localStorage.setItem('token', data.access_token);
     window.location.href = 'index.html';
   } catch {
     alert('登陆失败，请检查用户名或密码');


### PR DESCRIPTION
## Summary
- send urlencoded form data from login page
- store login token correctly
- document default admin credentials in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854dfb7c794832fb4b86cae0b179714