### PR TITLE
Implement new UI features

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -65,36 +65,12 @@ body {
   position: relative;
   width: 100%;
   height: 100%;
-  transform-style: preserve-3d;
 }
-.flip-card-inner.flip {
-  transform: rotateY(180deg);
+.flip-card-inner.flip .flip-card-front {
+  opacity: 0;
 }
-
-@keyframes flipBlur {
-  0%   { transform: rotateY(0) scale(1);   filter: blur(0); }
-  30%  { transform: rotateY(90deg) scale(1.3); filter: blur(4px); }
-  70%  { transform: rotateY(90deg) scale(0.8); filter: blur(4px); }
-  100% { transform: rotateY(180deg) scale(1); filter: blur(0); }
-}
-
-@keyframes flipBlurBack {
-  0%   { transform: rotateY(180deg) scale(1); filter: blur(0); }
-  30%  { transform: rotateY(90deg) scale(1.3); filter: blur(4px); }
-  70%  { transform: rotateY(90deg) scale(0.8); filter: blur(4px); }
-  100% { transform: rotateY(0) scale(1);   filter: blur(0); }
-}
-
-.flip-card-inner.animate-flip {
-  animation: flipBlur 0.6s forwards;
-}
-
-.flip-card-inner.animate-flip-back {
-  animation: flipBlurBack 0.6s forwards;
-}
-
-.card-word {
-  font-size: 8vh;
+.flip-card-inner.flip .flip-card-back {
+  opacity: 1;
 }
 .flip-card-front,
 .flip-card-back {
@@ -102,9 +78,14 @@ body {
   position: absolute;
   width: 100%;
   height: 100%;
+  transition: opacity 0.3s;
 }
 .flip-card-back {
-  transform: rotateY(180deg);
+  opacity: 0;
+}
+
+.card-word {
+  font-size: 8vh;
 }
 @keyframes slideUp {
   from { opacity: 0; transform: translateY(40px); }

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -7,6 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="css/style.css">
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="bg-gradient-to-br from-indigo-200 via-purple-200 to-pink-200 min-h-screen animate-fade-in">
   <button id="toggleNav" class="bg-gray-800 text-white p-2 rounded">☰</button>


### PR DESCRIPTION
## Summary
- restore streaming display for AI generated articles
- simplify study card flip animation to fade effect
- color "Change Password" button light gray
- extend Stats page with progress chart and answer counts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685502a50140832f8693222630346095